### PR TITLE
HTTP Auth Middleware

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3,30 +3,30 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 admin.initializeApp(functions.config().firebase);
 
-const slots = require('./slots')(admin);
-
+const express = require('express');
 // allow access from anywhere, since all functions will require authentication
 const cors = require('cors')({origin: true});
+const middleware = require('./middleware')(admin);
 
+const slots = require('./slots')(admin);
 const User = require("./user")(admin);
 
-exports.joinSlot = functions.https.onRequest((req, res) => {
-    cors(req, res, () => {
-      slots.join(req, res);
-    });
-});
+function makeHttpFunction(fn, middlewares) {
+  const router = new express.Router();
+  middlewares.forEach(m => {
+    router.use(m);
+  });
+  router.all('*', fn);
+  return functions.https.onRequest((req, res) => {
+    // NOTE: Adding a temporary fix for issue https://github.com/firebase/firebase-functions/issues/27
+    req.url = req.path ? req.url : `/${req.url}`;
+    return router(req, res);
+  });
+}
 
-exports.leaveSlot = functions.https.onRequest((req, res) => {
-    cors(req, res, () => {
-      slots.leave(req, res);
-    });
-});
-
-exports.closeSlot = functions.https.onRequest((req, res) => {
-    cors(req, res, () => {
-      slots.close(req, res);
-    });
-});
+exports.joinSlot = makeHttpFunction(slots.join, [cors, middleware.userAuthRequired]);
+exports.leaveSlot = makeHttpFunction(slots.leave, [cors, middleware.userAuthRequired]);
+exports.closeSlot = makeHttpFunction(slots.close, [cors]);
 
 exports.updateProfile = functions.database.ref("/accounts/{userId}/githubToken")
   .onWrite(event => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -24,9 +24,9 @@ function makeHttpFunction(fn, middlewares) {
   });
 }
 
-exports.joinSlot = makeHttpFunction(slots.join, [cors, middleware.userAuthRequired]);
-exports.leaveSlot = makeHttpFunction(slots.leave, [cors, middleware.userAuthRequired]);
-exports.closeSlot = makeHttpFunction(slots.close, [cors]);
+exports.joinEvent = makeHttpFunction(slots.join, [cors, middleware.userAuthRequired]);
+exports.leaveEvent = makeHttpFunction(slots.leave, [cors, middleware.userAuthRequired]);
+exports.closeEvent = makeHttpFunction(slots.close, [cors]);
 
 exports.updateProfile = functions.database.ref("/accounts/{userId}/githubToken")
   .onWrite(event => {

--- a/functions/middleware.js
+++ b/functions/middleware.js
@@ -1,0 +1,29 @@
+module.exports = function(admin) {
+
+	// Express middleware that validates Firebase ID Tokens passed in the Authorization HTTP header.
+	// The Firebase ID token needs to be passed as a Bearer token in the Authorization HTTP header like this:
+	// `Authorization: Bearer <Firebase ID Token>`.
+	// when decoded successfully, the ID Token content will be added as `req.user`.
+	function userAuthRequired(req, res, next) {
+		if (!req.headers.authorization || !req.headers.authorization.startsWith('Bearer ')) {
+			console.error('No Firebase ID token was passed as a Bearer token in the Authorization header.',
+					'Make sure you authorize your request by providing the following HTTP header:',
+					'Authorization: Bearer <Firebase ID Token>');
+			res.status(403).send('Unauthorized');
+			return;
+		}
+		const idToken = req.headers.authorization.split('Bearer ')[1];
+		admin.auth().verifyIdToken(idToken).then(decodedIdToken => {
+			req.user = decodedIdToken;
+			next();
+		}).catch(error => {
+			console.error('Error while verifying Firebase ID token:', error);
+			res.status(403).send('Unauthorized');
+		});
+	};
+
+	return {
+		userAuthRequired: userAuthRequired,
+	};
+
+};

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "cors": "^2.8.3",
+    "express": "^4.15.2",
     "firebase-admin": "^4.2.1",
     "firebase-functions": "^0.5.5",
     "github": "^9.2.0",

--- a/functions/slots.js
+++ b/functions/slots.js
@@ -21,7 +21,7 @@ function join(req, res) {
   // Get a few refs for convenience
   const db = admin.database();
   const rootRef = db.ref();
-  const slotRef = db.ref(`/slots/${slotId}`);
+  const slotRef = db.ref(`/events/${slotId}`);
 
   return slotRef.once('value')
     .then(snapshot => {
@@ -45,7 +45,7 @@ function join(req, res) {
       // Copy the slot data into the user's slots
       const slotCopy = _.cloneDeep(slot);
       delete slotCopy.state;
-      updates[`/accounts/${userId}/slots/${slotId}`] = slotCopy;
+      updates[`/accounts/${userId}/events/${slotId}`] = slotCopy;
 
       // Apply all updates atomically
       return rootRef.update(updates);
@@ -80,7 +80,7 @@ function leave (req, res) {
   // Get a few refs for convenience
   const db = admin.database();
   const rootRef = db.ref();
-  const accountSlotRef = db.ref(`/accounts/${userId}/slots/${slotId}`);
+  const accountSlotRef = db.ref(`/accounts/${userId}/events/${slotId}`);
 
   return accountSlotRef.once('value')
     .then(snapshot => {
@@ -102,7 +102,7 @@ function leave (req, res) {
       updates[`/requests/${slotId}/${userId}`] = null;
 
       // Delete the account slot
-      updates[`/accounts/${userId}/slots/${slotId}`] = null;
+      updates[`/accounts/${userId}/events/${slotId}`] = null;
 
       // Apply all updates atomically
       return rootRef.update(updates);
@@ -132,7 +132,7 @@ function close (req, res) {
   // Get a few refs for convenience
   const db = admin.database();
   const rootRef = db.ref();
-  const slotRef = db.ref(`/slots/${slotId}`);
+  const slotRef = db.ref(`/events/${slotId}`);
   const reqsRef = db.ref(`/requests/${slotId}`);
 
   return slotRef.once('value')
@@ -161,7 +161,7 @@ function close (req, res) {
       _.forEach(topics, (topic, topicId) => {
         // Add the topic data to each member's account slot
         topic.members.forEach(uid => {
-          updates[`/accounts/${uid}/slots/${slotId}/topic`] = topic.data;
+          updates[`/accounts/${uid}/events/${slotId}/topic`] = topic.data;
         });
 
         // Add the topic assignment (with members)

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -136,21 +136,15 @@ cors@^2.8.3:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
-debug@2, debug@^2.2.0:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
+debug@2, debug@2.6.1, debug@^2.2.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
-    ms "0.7.3"
+    ms "0.7.2"
 
 debug@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
-  dependencies:
-    ms "0.7.2"
-
-debug@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
     ms "0.7.2"
 
@@ -209,7 +203,7 @@ etag@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
 
-express@^4.0.33:
+express@^4.0.33, express@^4.15.2:
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.2.tgz#af107fc148504457f2dca9a6f2571d7129b97b35"
   dependencies:
@@ -393,22 +387,12 @@ json3@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
-jsonwebtoken@7.1.9:
+jsonwebtoken@7.1.9, jsonwebtoken@^7.1.9:
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-7.1.9.tgz#847804e5258bec5a9499a8dc4a5e7a3bae08d58a"
   dependencies:
     joi "^6.10.1"
     jws "^3.1.3"
-    lodash.once "^4.0.0"
-    ms "^0.7.1"
-    xtend "^4.0.1"
-
-jsonwebtoken@^7.1.9:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-7.4.0.tgz#515bf2bba070ec615bad97fd2e945027eb476946"
-  dependencies:
-    joi "^6.10.1"
-    jws "^3.1.4"
     lodash.once "^4.0.0"
     ms "^0.7.1"
     xtend "^4.0.1"
@@ -422,7 +406,7 @@ jwa@^1.1.4:
     ecdsa-sig-formatter "1.0.9"
     safe-buffer "^5.0.1"
 
-jws@^3.1.3, jws@^3.1.4:
+jws@^3.1.3:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.4.tgz#f9e8b9338e8a847277d6444b1464f61880e050a2"
   dependencies:

--- a/webapp/src/app/slot.service.ts
+++ b/webapp/src/app/slot.service.ts
@@ -60,8 +60,10 @@ export class SlotService {
   join(slot: Slot) {
     console.log('close item:', slot);
     let token = this.userService.getToken().then(token => {
-
-      let headers = new Headers({ 'Content-Type': 'application/json' });
+      let headers = new Headers({
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      });
       let endpoint = 'https://us-central1-hubbub-159904.cloudfunctions.net/joinSlot';
       return this.http.post(endpoint, {id: slot.$key, userId: this.uid}, { headers: headers })
         // Call map on the response observable to get the parsed people object

--- a/webapp/src/app/slot.service.ts
+++ b/webapp/src/app/slot.service.ts
@@ -59,14 +59,18 @@ export class SlotService {
 
   join(slot: Slot) {
     console.log('close item:', slot);
-    let headers = new Headers({ 'Content-Type': 'application/json' });
-    let endpoint = 'https://us-central1-hubbub-159904.cloudfunctions.net/joinSlot';
-    return this.http.post(endpoint, {id: slot.$key, userId: this.uid}, { headers: headers })
-      // Call map on the response observable to get the parsed people object
-      //.map(res => res.json())
-      // Subscribe to the observable to get the parsed people object and attach it to the
-      // component
-      .subscribe(res => console.log('res', res));
+    let token = this.userService.getToken().then(token => {
+
+      let headers = new Headers({ 'Content-Type': 'application/json' });
+      let endpoint = 'https://us-central1-hubbub-159904.cloudfunctions.net/joinSlot';
+      return this.http.post(endpoint, {id: slot.$key, userId: this.uid}, { headers: headers })
+        // Call map on the response observable to get the parsed people object
+        //.map(res => res.json())
+        // Subscribe to the observable to get the parsed people object and attach it to the
+        // component
+        .subscribe(res => console.log('res', res));
+    })
+
   }
 
 }

--- a/webapp/src/app/user.service.ts
+++ b/webapp/src/app/user.service.ts
@@ -48,6 +48,9 @@ export class UserService {
     })
   }
 
+  getToken(forceRefresh: boolean = false) {
+    return this.afAuth.auth.currentUser.getToken(forceRefresh);
+  }
   login() {
     const provider = new firebase.auth.GithubAuthProvider();
     this.afAuth.auth.signInWithRedirect(provider);


### PR DESCRIPTION
Adds a `userAuthRequired` middleware and uses it for `joinSlot` and `leaveSlot`. Fixes #18.

Adds express middleware that validates Firebase ID Tokens passed in the Authorization HTTP header. The Firebase ID token needs to be passed as a Bearer token in the Authorization HTTP header like this:
`Authorization: Bearer <Firebase ID Token>`.
when decoded successfully, the ID Token content will be added as `req.user`.