### PR TITLE
Hosting Rewrite for OAuth

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -18,6 +18,10 @@
     ],
     "rewrites": [
       {
+        "source": "/oauth",
+        "destination": "/assets/oauth.html"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }


### PR DESCRIPTION
Add a rewrite rule for `/oauth` to point at the static `oauth.html` in the angular assets directory.  This means the client can just use `/oauth` for the callback URL, even if the webapp moves files around or stops using angular.