### PR TITLE
Remove the user.js dependency on admin

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -9,7 +9,7 @@ const cors = require('cors')({origin: true});
 const middleware = require('./middleware')(admin);
 
 const slots = require('./slots')(admin);
-const User = require("./user")(admin);
+const User = require("./user");
 
 function makeHttpFunction(fn, middlewares) {
   const router = new express.Router();
@@ -30,7 +30,8 @@ exports.closeEvent = makeHttpFunction(slots.close, [cors, middleware.userAuthReq
 
 exports.updateProfile = functions.database.ref("/accounts/{userId}/githubToken")
   .onWrite(event => {
-    return User.findById(event.params.userId).then( (user) => {
+    const db = admin.database();
+    return User.findById(db, event.params.userId).then( (user) => {
       return user.updateProfile();
     });
   });

--- a/functions/test/user-test.js
+++ b/functions/test/user-test.js
@@ -1,10 +1,11 @@
-const User = require("../user")(config.admin);
+const User = require("../user");
 
 describe("User", function () {
   this.timeout(10000);
 
   let
     userPromise
+  , db = config.db
   , id = "S7osJegfQvWPhpSNSWsBwMroUgo2"; // id of hubbubducky; will need to be updated if this changes
 
   if (!config.isTestDatabase) {
@@ -15,7 +16,7 @@ describe("User", function () {
         describe("when passed user id that exists in firebase", () => {
 
           beforeEach(() => {
-            userPromise = User.findById(id);
+            userPromise = User.findById(db, id);
           });
 
           it("user has an oauth token", () => {
@@ -30,7 +31,7 @@ describe("User", function () {
 
     describe("when there is a user", () => {
       beforeEach(() => {
-        userPromise = User.findById(id);
+        userPromise = User.findById(db, id);
       });
 
       describe(".updateProfile", function () {

--- a/functions/user.js
+++ b/functions/user.js
@@ -1,80 +1,74 @@
-const config = require("./config");
-const GitHubbub = require('./githubbub');
-const util = require("util");
-const Promise = require('bluebird');
 const _ = require("lodash");
+const GitHubbub = require('./githubbub');
+const Promise = require('bluebird');
+const ServerValue = require('firebase-admin').database.ServerValue;
 
-module.exports = function(admin) {
-
-  class User {
-    static findById(id) {
-      let db = admin.database();
-      return Promise.props({
-        account: db.ref(`/accounts/${id}`).once("value").then(snapshot => {
-          return snapshot.val();
-        }),
-        profile: db.ref(`/profiles/${id}`).once("value").then(snapshot => {
-          return snapshot.val();
-        })
-      }).then(data => {
-        let
-          account = data.account || {}
-        , profile = data.profile || {};
-
-        return new User({
-          id: id,
-          email: account.email,
-          githubToken: account.githubToken,
-          updatedAt: account.updatedAt,
-          githubCreatedAt: account.githubCreatedAt,
-          name: profile.name,
-          handle: profile.handle,
-          photo: profile.photo
-        });
-      });
-    }
-
-    constructor (attributes) {
-      this.id = attributes.id;
-      this.email = attributes.email;
-      this.githubToken = attributes.githubToken;
-      this.updatedAt = attributes.updatedAt;
-      this.githubCreatedAt = attributes.githubCreatedAt;
-      this.name = attributes.name;
-      this.handle = attributes.handle;
-      this.photo = attributes.photo;
-      this.uid = attributes.uid;
-      this.db = admin.database();
-      this.github = new GitHubbub(this.githubToken);
-    }
-
-    updateProfile () {
-      let
-        self = this
-      , db = this.db
-      , accountRef = db.ref(`/accounts/${this.id}`)
-      , profileRef = db.ref(`/profiles/${this.id}`);
-      return this.github.profile().then(data => {
-        let newProfile = {
-          photo: data.avatar_url,
-          name: data.name,
-          handle: data.login,
-        };
-        return Promise.all([
-          accountRef.update({
-            githubCreatedAt: data.created_at,
-            updatedAt: admin.database.ServerValue.TIMESTAMP,
-            handle: data.login,     // for debugging via Firebase Console
-          }),
-          profileRef.update(newProfile)
-        ]).then(() => {
-          return newProfile;        // for testing
-        });
+class User {
+  static findById(db, id) {
+    return Promise.props({
+      account: db.ref(`/accounts/${id}`).once("value").then(snapshot => {
+        return snapshot.val();
+      }),
+      profile: db.ref(`/profiles/${id}`).once("value").then(snapshot => {
+        return snapshot.val();
       })
-    }
+    }).then(data => {
+      let
+        account = data.account || {}
+      , profile = data.profile || {};
+
+      return new User(db, {
+        id: id,
+        email: account.email,
+        githubToken: account.githubToken,
+        updatedAt: account.updatedAt,
+        githubCreatedAt: account.githubCreatedAt,
+        name: profile.name,
+        handle: profile.handle,
+        photo: profile.photo
+      });
+    });
   }
 
-  return User;
+  constructor(db, attributes) {
+    this.db = db;
 
+    this.id = attributes.id;
+    this.email = attributes.email;
+    this.githubToken = attributes.githubToken;
+    this.updatedAt = attributes.updatedAt;
+    this.githubCreatedAt = attributes.githubCreatedAt;
+    this.name = attributes.name;
+    this.handle = attributes.handle;
+    this.photo = attributes.photo;
+    this.uid = attributes.uid;
+    this.github = new GitHubbub(this.githubToken);
+  }
+
+  updateProfile () {
+    let
+      self = this
+    , db = this.db
+    , accountRef = db.ref(`/accounts/${this.id}`)
+    , profileRef = db.ref(`/profiles/${this.id}`);
+    return this.github.profile().then(data => {
+      let newProfile = {
+        photo: data.avatar_url,
+        name: data.name,
+        handle: data.login,
+      };
+      return Promise.all([
+        accountRef.update({
+          githubCreatedAt: data.created_at,
+          updatedAt: ServerValue.TIMESTAMP,
+          handle: data.login,     // for debugging via Firebase Console
+        }),
+        profileRef.update(newProfile)
+      ]).then(() => {
+        return newProfile;        // for testing
+      });
+    })
+  }
 }
 
+module.exports = User;

--- a/functions/user.js
+++ b/functions/user.js
@@ -1,7 +1,7 @@
 const _ = require("lodash");
 const GitHubbub = require('./githubbub');
 const Promise = require('bluebird');
-const ServerValue = require('firebase-admin').database.ServerValue;
+const SERVER_TIMESTAMP = require('firebase-admin').database.ServerValue.TIMESTAMP;
 
 class User {
   static findById(db, id) {
@@ -60,7 +60,7 @@ class User {
       return Promise.all([
         accountRef.update({
           githubCreatedAt: data.created_at,
-          updatedAt: ServerValue.TIMESTAMP,
+          updatedAt: SERVER_TIMESTAMP,
           handle: data.login,     // for debugging via Firebase Console
         }),
         profileRef.update(newProfile)


### PR DESCRIPTION
Instead of initializing its own database reference, the `User` class now requires a database be passed as a parameter.  This makes it easier to `require` and test.