### PR TITLE
OAuth HTTPS Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,14 @@ Function, we need to set up billing for the account.
       Firebase Auth console).  Here's an example: ![Github app registration form][github-register-app]
    6. Submit the form and then GitHub will show you a page with your Client ID
       and Client Secret.
-   7. Go back to the Firebase Console and fill that in and click "Save"
+   7. You will need to put those secrets in two place:
+      1. In the Firebase Console, fill the Authentication details for GitHub and click "Save"
+      2. For the mobile clients to work, the github secret also needs to be
+      available as a Cloud Functions server configuration:
+        ```
+        firebase functions:config:set github.client_id="<client_id>" github.client_secret="<client_secret>"
+        ```
+
 5. then install node modules for web app and functions, build the web app,
 and deploy everything!
 
@@ -123,7 +130,7 @@ The Admin Web UI isn't finished, so for the app to work end-to-end we need to
 seed the database with events (which would be nice for open source developers
 and interactive testing anyhow)
 
-### Functions
+### Developing Cloud Functions
 
 Testing Cloud Functions
 ```

--- a/functions/index.js
+++ b/functions/index.js
@@ -8,6 +8,7 @@ const admin = require('firebase-admin');
 admin.initializeApp(functions.config().firebase);
 
 const middleware = require('./middleware')(admin);
+const oauth = require('./oauth');
 const profile = require('./profile');
 const slots = require('./slots')(admin);
 
@@ -71,6 +72,19 @@ exports.updateProfileCron = functions.https.onRequest((req, res) => {
   return profile.cron(admin.database())
     .then(() => {
       res.sendStatus(200);
+    })
+    .catch(err => {
+      console.error(err);
+      res.sendStatus(500);
+    });
+});
+
+exports.githubToken = functions.https.onRequest((req, res) => {
+  const config = functions.config().github;
+  const github = new oauth.GitHub(config.client_id, config.client_secret);
+  return github.getToken(req.body.code)
+    .then(data => {
+      res.send(data);
     })
     .catch(err => {
       console.error(err);

--- a/functions/oauth.js
+++ b/functions/oauth.js
@@ -1,0 +1,32 @@
+const request = require('request-promise');
+
+class GitHub {
+  constructor(clientId, clientSecret, opts) {
+    if (!clientId || !clientSecret) {
+      throw new Error('Missing required clientId/Secret');
+    }
+    opts = opts || {};
+
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.endpoint = 'https://github.com' || opts.endpoint;
+  }
+
+  getToken(code) {
+    const opts = {
+      method: 'POST',
+      uri: `${this.endpoint}/login/oauth/access_token`,
+      body: {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code: code,
+      },
+      json: true,
+    };
+    return request(opts);
+  }
+}
+
+module.exports = {
+  GitHub: GitHub,
+};

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,9 @@
     "firebase-admin": "^4.2.1",
     "firebase-functions": "^0.5.5",
     "github": "^9.2.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.1"
   },
   "scripts": {
     "test": "mocha test",

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,6 +19,8 @@
   "private": true,
   "devDependencies": {
     "mocha": "^3.3.0",
+    "nock": "^9.0.13",
+    "uuid": "^3.0.1",
     "yakbak": "^2.5.0"
   }
 }

--- a/functions/test/oauth-test.js
+++ b/functions/test/oauth-test.js
@@ -1,0 +1,63 @@
+const _ = require('lodash');
+const nock = require('nock');
+const uuid = require('uuid');
+
+const oauth = require('../oauth');
+
+describe("OAuth", () => {
+  describe("GitHub", () => {
+    it("constructor requires clientId and clientSecret", () => {
+      assert.throws(() => {
+        new oauth.GitHub();
+      });
+    });
+
+    describe("getToken()", () => {
+      var clientId;
+      var clientSecret;
+      var code;
+      var accessToken;
+      var client;
+
+      beforeEach(() => {
+        clientId = uuid.v4();
+        clientSecret = uuid.v4();
+        code = uuid.v4();
+        accessToken = uuid.v4();
+        client = new oauth.GitHub(clientId, clientSecret);
+
+        nock('https://github.com')
+          .post('/login/oauth/access_token', {
+            client_id: clientId,
+            client_secret: clientSecret,
+            code: code,
+          })
+          .reply(200, {
+            access_token: accessToken,
+          });
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+      });
+
+      it("sends expected POST parameters", (done) => {
+        client.getToken(code)
+          .then(data => {
+            done();
+          })
+          .catch(done);
+      });
+
+      it("parses and returns JSON response", (done) => {
+        client.getToken(code)
+          .then(data => {
+            assert.ok(data);
+            assert.equal(data.access_token, accessToken);
+            done();
+          })
+          .catch(done);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR implements an HTTPS function that can exchange an oauth `code` for an `access_token` via the GitHub API.

Note: the following commands need to be run before the function can be used. Not exactly sure where to put it in the README since it's really only necessary for the mobile clients.
```
firebase use <env>
firebase functions:config:set github.client_id="<client_id>" github.client_secret="<client_secret>"
```