### PR TITLE
Handle unrecoverable GitHub errors during profile update

### DIFF
--- a/functions/profile.js
+++ b/functions/profile.js
@@ -25,6 +25,17 @@ function update(db, uid) {
       // Fetch and save new profile data from GitHub
       return user.updateProfile();
     })
+    .catch(err => {
+      // If the oauth token was invalid, delete it and allow the queue
+      // entry and profileNeedsUpdate flag to be cleaned up as usual.
+      if (err.code === 401) {
+        console.log(`Invalid githubToken for uid=${uid}`);
+        return db.ref(`/accounts/${uid}/githubToken`).set(null);
+      }
+
+      // All other errors are unexpected
+      throw err;
+    })
     .then(() => {
       // Atomically delete the queue entry and clear profileNeedsUpdate flag
       const updates = {}


### PR DESCRIPTION
Without this the queue never drains when trying to update a user who has an invalid oauth token.  This error handling is already described in the doc, it was just never implemented 🙈 